### PR TITLE
[UnivAuth, Login] 대학교 이메일 수정 api 변경, 로그인 요청 후 리다이렉트 추가 및 응답 변경

### DIFF
--- a/src/main/java/com/dungzi/backend/domain/univ/application/UnivService.java
+++ b/src/main/java/com/dungzi/backend/domain/univ/application/UnivService.java
@@ -3,8 +3,6 @@ package com.dungzi.backend.domain.univ.application;
 import com.dungzi.backend.domain.univ.dao.UnivDao;
 import com.dungzi.backend.domain.univ.domain.Univ;
 import com.dungzi.backend.global.common.CommonCode;
-import com.dungzi.backend.global.common.error.AuthErrorCode;
-import com.dungzi.backend.global.common.error.AuthException;
 import com.dungzi.backend.global.common.error.UnivErrorCode;
 import com.dungzi.backend.global.common.error.UnivException;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -22,11 +18,15 @@ public class UnivService {
 
     private final UnivDao univDao;
 
-    public boolean isUnivDomain(String email, String univId) {
-        String domain = email.substring(email.lastIndexOf("@")+1);
+    public void checkUnivDomain(String email, String univId) {
         Univ univ = univDao.findById(univId)
                 .orElseThrow(() -> new UnivException(UnivErrorCode.UNIV_NOT_FOUND));
-        return univ.isDomain(domain); //TODO : 예외 핸들링하기!!
+        checkUnivDomain(email, univ); //TODO : 예외 핸들링하기!!
+    }
+
+    public void checkUnivDomain(String email, Univ univ) {
+        String domain = email.substring(email.lastIndexOf("@")+1);
+        univ.checkDomain(domain);
     }
 
     public Univ getUniv(String univId) {

--- a/src/main/java/com/dungzi/backend/domain/univ/application/UnivService.java
+++ b/src/main/java/com/dungzi/backend/domain/univ/application/UnivService.java
@@ -25,7 +25,7 @@ public class UnivService {
     }
 
     public void checkUnivDomain(String email, Univ univ) {
-        String domain = email.substring(email.lastIndexOf("@")+1);
+        String domain = email.split("@")[1];
         univ.checkDomain(domain);
     }
 

--- a/src/main/java/com/dungzi/backend/domain/univ/domain/Univ.java
+++ b/src/main/java/com/dungzi/backend/domain/univ/domain/Univ.java
@@ -29,10 +29,9 @@ public class Univ {
 
     private String emailDomain;
 
-    public boolean isDomain(String domain) {
+    public void checkDomain(String domain) {
         if(this.getEmailDomain().equals(domain)){
             log.info("univ email domain is correct");
-            return true;
         }
         else{
             throw new UnivException(UnivErrorCode.UNIV_DOMAIN_MISMATCH);

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
     // TODO : 인증 요청 대학교 도메인과 현제 이메일 도메인 일치 확인 로직 추가할 것 (테스트 시에도 불편할 예정)
     @GetMapping("/code")
     public CommonResponse sendAuthEmail(@RequestParam String email, @RequestParam(value = "univ") String univId) throws Exception {
-        log.info("[API] auth/email-auth/send");
+        log.info("[API] auth/code");
         univService.checkUnivDomain(email, univId);
         String code = emailService.sendSimpleMessage(email);
         log.info("이메일 전송 완료. 인증코드 : {}", code);

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -99,8 +99,6 @@ public class AuthController {
 
         HashMap<String, String> token = kakaoService.getKakaoAccessToken(code);
         String kakao_access_token = token.get(ACCESS_TOKEN);
-//        String refresh_token = token.get(REFRESH_TOKEN);
-
 
         // TODO : 예외처리 Handler 사용하여 중복코드 개선하기
         User kakaoUser;
@@ -113,12 +111,7 @@ public class AuthController {
             throw new AuthException(AuthErrorCode.KAKAO_FAILED);
         }
 
-        // TODO : 코드리뷰 필요 - 회원 확인 코드가 Controller와 Service 중 어디에 위치하는 것이 좋을까?
-        // Conroller에 위치할 경우 : login 메서드와 회원확인 메서드 분리. if-else문 사용
-        // Service에 위치할 경우 : login 메서드 안에 회원확인 로직 포함. 예외 throw 하여 try-catch문 사용
-//        boolean isRegistered = authService.isRegistered(kakaoUser);
 //        UserResponseDto.KakaoLogin responseDto = new UserResponseDto.KakaoLogin();
-//        responseDto.setIsUser(isRegistered);
 
         try {
             User loginUser = authService.login(kakaoUser);

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -3,7 +3,6 @@ package com.dungzi.backend.domain.user.api;
 import com.dungzi.backend.domain.univ.application.UnivAuthService;
 import com.dungzi.backend.domain.univ.application.UnivService;
 import com.dungzi.backend.domain.univ.domain.Univ;
-import com.dungzi.backend.domain.univ.domain.UnivAuth;
 import com.dungzi.backend.domain.user.application.AuthService;
 import com.dungzi.backend.domain.user.application.EmailService;
 import com.dungzi.backend.domain.user.application.KakaoService;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -40,7 +38,7 @@ public class AuthController {
     @GetMapping("/code")
     public CommonResponse sendAuthEmail(@RequestParam String email, @RequestParam(value = "univ") String univId) throws Exception {
         log.info("[API] auth/email-auth/send");
-        univService.isUnivDomain(email, univId);
+        univService.checkUnivDomain(email, univId);
         String code = emailService.sendSimpleMessage(email);
         log.info("이메일 전송 완료. 인증코드 : {}", code);
         UserResponseDto.SendEmailAuth response = UserResponseDto.SendEmailAuth.builder()

--- a/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
@@ -14,12 +14,7 @@ import com.dungzi.backend.global.common.error.AuthErrorCode;
 import com.dungzi.backend.global.common.error.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -30,9 +25,9 @@ public class UserUtilController {
     private final UnivService univService;
     private final UnivAuthService univAuthService;
 
-    @PatchMapping("/email-auth")
+    @PutMapping("/univs")
     public CommonResponse updateUserEmailAuth(@RequestBody UserRequestDto.UpdateEmailAuth requestDto) {
-        log.info("[API] users/email-auth");
+        log.info("[API] users/univs");
         User user = null;
         try {
             user = authService.getUserFromSecurity();
@@ -42,8 +37,10 @@ public class UserUtilController {
                 return CommonResponse.toErrorResponse(AuthErrorCode.GUEST_USER);
             }
         }
+
         Univ univ = univService.getUniv(requestDto.getUnivId());
-        // TODO : 대학교 이메일 도메인 일치 확인 univService
+        univService.checkUnivDomain(requestDto.getUnivEmail(), univ);
+
         UnivAuth univAuth = univAuthService.updateUserEmailAuth(user, univ, requestDto.getUnivEmail(), requestDto.getIsEmailChecked());
         return CommonResponse.toResponse(CommonCode.OK, new UserResponseDto.UpdateEmailAuth(user, univAuth));
     }


### PR DESCRIPTION
1. 대학교 이메일 수정 api 변경
대학교 이메일 도메인 확인 로직을 조금 수정했고
메서드와 url을 아래와 같이 변경했습니다.

- 기존 : POST /users/email-auth
- 반영 :  PUT /users/univs

- 설명
user의 univ 정보를 수정한다는 의미를 살려 url을 수정했습니다.
또한 대학교 인증 정보를 담는 UnivAuth가 기존에 존재하지 않는 사용자의 경우 새로 생성되고,
기존에 다른 대학을 인증했던 사용자는 새로운 인증 정보로 update 되어서
PUT 이 더 어울린다고 생각했습니다.(생성+수정)


2. 카카오 로그인 요청 후 프론트 페이지로 리다이렉트 추가, 응답 변경
프론트 측 요청으로 카카오 로그인 후 성공/실패 여부에 따라 각각 다른 프론트 페이지로 리다이렉트 처리를 추가했습니다.
리다이렉트 처리로 기존에 응답 body로 전송하던 내용이 확인이 안되어서
로그인 성공 시 body는 삭제, 로그인 실패 시 header 사용으로 변경했습니다.
자세한 변경 내용은 [로그인 api 명세](https://www.notion.so/API-b405ff911f554e69bff99d4529aa6a39?p=367e71b8181b4ffd9e288732933ac629&pm=c) 참고해주시면 됩니다!

확인 부탁드립니다!