### PR TITLE
Swagger, Validation handling, getUserFromSecurity() 오류코드 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     //chatting
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    //validator
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
 }

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -18,13 +18,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Optional;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -50,7 +54,7 @@ public class AuthController {
             }
     )
     @GetMapping("/code")
-    public CommonResponse sendAuthEmail(@RequestParam String email, @RequestParam(value = "univ") String univId) throws Exception {
+    public CommonResponse getAuthCodeEmail(@RequestParam @Email String email, @RequestParam(value = "univ") @NotBlank String univId) throws Exception {
         log.info("[API] auth/code");
         univService.checkUnivDomain(email, univId);
         String code = emailService.sendSimpleMessage(email);
@@ -121,7 +125,6 @@ public class AuthController {
         }
 
     }
-
 
 
     ///////////TODO : 추후 제거

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -40,9 +40,15 @@ public class AuthController {
     private final UnivAuthService univAuthService;
 
     private final String ACCESS_TOKEN = "access_token";
-//    private final String REFRESH_TOKEN = "refresh_token"; //TODO : 카카오 refresh token은 저장해둘 필요 없을까? 탈퇴나 로그아웃 시
+//    private final String REFRESH_TOKEN = "refresh_token";
 
-    // TODO : 인증 요청 대학교 도메인과 현제 이메일 도메인 일치 확인 로직 추가할 것 (테스트 시에도 불편할 예정)
+    @Operation(summary = "이메일 인증코드 api", description = "이메일 인증코드 전송 요청 api")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "회원 가입 성공"),
+                    @ApiResponse(responseCode = "500", description = "카카오 관련 에러")
+            }
+    )
     @GetMapping("/code")
     public CommonResponse sendAuthEmail(@RequestParam String email, @RequestParam(value = "univ") String univId) throws Exception {
         log.info("[API] auth/code");
@@ -56,19 +62,18 @@ public class AuthController {
         return CommonResponse.toResponse(CommonCode.OK, response);
     }
 
+    @Operation(summary = "카카오 회원가입 api", description = "카카오 계정 연동 회원가입")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "회원 가입 성공"),
+                    @ApiResponse(responseCode = "500", description = "카카오 관련 에러")
+            }
+    )
     @PostMapping("/kakao")
     public CommonResponse signUpByKakao(@RequestBody UserRequestDto.SignUpByKakao requestDto) {
         log.info("[API] auth/kakao");
 
-        // TODO : 예외처리 Handler 사용하여 중복코드 개선하기
-        User kakaoUser;
-        try {
-            kakaoUser = kakaoService.getKakaoUserInfo(requestDto.getKakaoAccessToken());
-        } catch (Exception e) {
-            log.warn("getKakaoUserInfo failed");
-            e.printStackTrace();
-            return CommonResponse.toErrorResponse(AuthErrorCode.KAKAO_FAILED);
-        }
+        User kakaoUser = kakaoService.getKakaoUserInfo(requestDto.getKakaoAccessToken());
 
         // TODO : 형식적 유효성 검사가 원래 컨트롤러에서 하는 일이니 여기서 Optional로 하는 게 맞을 듯 (필수값이 아니니까 여기서 isPresent를 확인하진 않아도 되지 않을까?
         Optional<String> nicknameOp = Optional.ofNullable(requestDto.getNickname());
@@ -86,12 +91,11 @@ public class AuthController {
     }
 
     //카카오 로그인
-    //TODO : swagger 작성하기
-    @Operation(summary = "카카오 로그인 api", description = "카카오 계정 연동 로그인 api")
+    @Operation(summary = "카카오 로그인 api", description = "카카오 계정 연동 로그인")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "회원 가입된 유저"),
-                    @ApiResponse(responseCode = "", description = "새로운 방 생성"),
+                    @ApiResponse(responseCode = "200", description = "회원 가입된 유저. 로그인 성공"),
+                    @ApiResponse(responseCode = "200", description = "가입되지 않은 유저인 경우 카카오 액세스 토큰 전달"),
                     @ApiResponse(responseCode = "500", description = "카카오 관련 에러")
             }
     )
@@ -102,36 +106,20 @@ public class AuthController {
         HashMap<String, String> token = kakaoService.getKakaoAccessToken(code);
         String kakao_access_token = token.get(ACCESS_TOKEN);
 
-        // TODO : 예외처리 Handler 사용하여 중복코드 개선하기
-        User kakaoUser;
-        try {
-            kakaoUser = kakaoService.getKakaoUserInfo(kakao_access_token);
-        } catch (Exception e) {
-            log.info("getKakaoUserInfo failed");
-            e.printStackTrace();
-//            return CommonResponse.toErrorResponse(AuthErrorCode.KAKAO_FAILED);
-            throw new AuthException(AuthErrorCode.KAKAO_FAILED);
-        }
-
-//        UserResponseDto.KakaoLogin responseDto = new UserResponseDto.KakaoLogin();
+        User kakaoUser = kakaoService.getKakaoUserInfo(kakao_access_token);
 
         try {
             User loginUser = authService.login(kakaoUser);
             authService.setCookieTokenInResponse(httpServletResponse, loginUser); //위로 합치기
-//            responseDto.setUuid(loginUser.getUserId());
-//            responseDto.setIsUser(true);
             httpServletResponse.sendRedirect(LOGIN_SUCCESS_REDIRECT_URL);
         }
         catch(AuthException authException) {
             if(authException.getCode() == AuthErrorCode.NOT_EXIST_USER){
-//                responseDto.setKakaoAccessToken(kakao_access_token);
-//                responseDto.setIsUser(false);
                 httpServletResponse.addHeader(LOGIN_FAIL_KAKAO_TOKEN_HEADER, kakao_access_token);
                 httpServletResponse.sendRedirect(LOGIN_FAIL_REDIRECT_URL);
             }
         }
 
-//        return CommonResponse.toResponse(CommonCode.OK, responseDto);
     }
 
 

--- a/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
@@ -13,6 +13,9 @@ import com.dungzi.backend.global.common.CommonCode;
 import com.dungzi.backend.global.common.CommonResponse;
 import com.dungzi.backend.global.common.error.AuthErrorCode;
 import com.dungzi.backend.global.common.error.AuthException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -26,6 +29,13 @@ public class UserUtilController {
     private final UnivService univService;
     private final UnivAuthService univAuthService;
 
+    @Operation(summary = "사용자 프로필 api", description = "사용자 기본 정보 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가")
+            }
+    )
     @GetMapping("/profile")
     public CommonResponse getUserProfile() {
         log.info("[API] users/profile");
@@ -34,18 +44,17 @@ public class UserUtilController {
         return CommonResponse.toResponse(CommonCode.OK, UserUtilResponseDto.GetUserProfile.toDto(user, univAuth));
     }
 
+    @Operation(summary = "대학교 이메일 인증 api", description = "대학교 이메일 인증 정보 저장")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가")
+            }
+    )
     @PutMapping("/univs")
     public CommonResponse updateUserEmailAuth(@RequestBody UserRequestDto.UpdateEmailAuth requestDto) {
         log.info("[API] users/univs");
-        User user = null;
-        try {
-            user = authService.getUserFromSecurity();
-        }
-        catch (AuthException authException){
-            if(authException.getCode() == CommonCode.UNAUTHORIZED){
-                return CommonResponse.toErrorResponse(AuthErrorCode.GUEST_USER);
-            }
-        }
+        User user = authService.getUserFromSecurity();
 
         Univ univ = univService.getUniv(requestDto.getUnivId());
         univService.checkUnivDomain(requestDto.getUnivEmail(), univ);

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication instanceof AnonymousAuthenticationToken) {
             log.info("User in spring security is anonymous");
-            throw new AuthException(CommonCode.UNAUTHORIZED);
+            throw new AuthException(AuthErrorCode.GUEST_USER);
         }
         else{
             return (User) authentication.getPrincipal();

--- a/src/main/java/com/dungzi/backend/domain/user/application/KakaoService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/KakaoService.java
@@ -2,6 +2,8 @@ package com.dungzi.backend.domain.user.application;
 
 import com.dungzi.backend.domain.user.dao.UserDao;
 import com.dungzi.backend.domain.user.domain.User;
+import com.dungzi.backend.global.common.error.AuthErrorCode;
+import com.dungzi.backend.global.common.error.AuthException;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -96,7 +98,7 @@ public class KakaoService {
     }
 
     // access_token을 이용하여 사용자 정보 조회
-    public User getKakaoUserInfo(String token) throws Exception {
+    public User getKakaoUserInfo(String token) {
         log.info("[SERVICE] getKakaoUserInfo");
 
         User user = new User();
@@ -178,8 +180,10 @@ public class KakaoService {
 
             br.close();
 
-        } catch (IOException e) {
+        } catch (Exception e) {
+            log.warn("getKakaoUserInfo failed");
             e.printStackTrace();
+            throw new AuthException(AuthErrorCode.KAKAO_FAILED);
         }
 
         return user;

--- a/src/main/java/com/dungzi/backend/global/common/CommonResponse.java
+++ b/src/main/java/com/dungzi/backend/global/common/CommonResponse.java
@@ -37,17 +37,17 @@ public class CommonResponse {
                 .build();
     }
 
-    public static CommonResponse toErrorResponse(AuthErrorCode authErrorCode) {
-        return CommonResponse.builder()
-                .code(authErrorCode.getCode().value())
-                .message(authErrorCode.getMessage())
-                .build();
-    }
-
     public static CommonResponse toErrorResponse(Code code) {
         return CommonResponse.builder()
                 .code(code.getCode().value())
                 .message(code.getMessage())
+                .build();
+    }
+
+    public static CommonResponse toErrorResponse(Code code, String message) {
+        return CommonResponse.builder()
+                .code(code.getCode().value())
+                .message(message)
                 .build();
     }
 

--- a/src/main/java/com/dungzi/backend/global/common/error/AuthErrorCode.java
+++ b/src/main/java/com/dungzi/backend/global/common/error/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode implements Code {
     GUEST_USER(HttpStatus.UNAUTHORIZED, "사용자 정보를 확인할 수 없습니다. 비회원 사용자입니다."), //401
     NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "이 uuid 에 해당하는 사용자가 존재하지 않습니다."), //401
     KAKAO_FAILED(HttpStatus.CONFLICT, "카카오관련 처리를 실행할 수 없습니다."), //500
+    EMAIL_FORMAT_INCORRECT(HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."), //400
     ;
 
     private HttpStatus code;

--- a/src/main/java/com/dungzi/backend/global/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dungzi/backend/global/common/error/GlobalExceptionHandler.java
@@ -1,12 +1,19 @@
 package com.dungzi.backend.global.common.error;
 
 import com.dungzi.backend.global.common.Code;
+import com.dungzi.backend.global.common.CommonCode;
 import com.dungzi.backend.global.common.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.Set;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
@@ -16,8 +23,33 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(code);
     }
 
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> handleValidException(ConstraintViolationException e){
+        Code code = CommonCode.BAD_REQUEST;
+        Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
+        StringBuilder message = new StringBuilder();
+        if(constraintViolations != null) {
+            for(ConstraintViolation c : constraintViolations){
+                String[] paths = c.getPropertyPath().toString().split("\\.");
+                String path = paths.length > 0 ? paths[paths.length - 1] : "";
+                message.append(path);
+                message.append(" : ");
+                message.append(c.getMessage());
+                message.append(". ");
+            }
+        }
+        return handleExceptionInternal(code, message.toString());
+    }
+
     private ResponseEntity<Object> handleExceptionInternal(Code code){
         CommonResponse errorResponse = CommonResponse.toErrorResponse(code);
+        return ResponseEntity
+                .status(code.getCode())
+                .body(errorResponse);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Code code, String message){
+        CommonResponse errorResponse = CommonResponse.toErrorResponse(code, message);
         return ResponseEntity
                 .status(code.getCode())
                 .body(errorResponse);

--- a/src/main/java/com/dungzi/backend/global/config/WebConfig.java
+++ b/src/main/java/com/dungzi/backend/global/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.dungzi.backend.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true) // 쿠키 전송 허용
 //                .maxAge(3000) // 원하는 시간만큼 pre-flight 리퀘스트 캐싱
                 ;
+    }
+
+    @Bean
+    public MethodValidationPostProcessor methodValidationPostProcessor() {
+        return new MethodValidationPostProcessor();
     }
 }


### PR DESCRIPTION
1. getUserFromSecurity() 메서드가 사용자 정보를 가져올 수 없을 경우에 던지는 오류 코드를 
CommonCode.UNAUTHORIZED 에서 
AuthErrorCode.GUEST_USER 로 변경했습니다.
한번 더 try catch 문을 사용하는 대신 바로 핸들러에 GUEST_USER 가 잡히도록 하려고 변경했습니다.


2. swagger 기초적인 것 먼저 작성했습니다.
추가로 예외처리 할 것들 있는지 확인하면서 validation 진행하고나면 좀더 추가될 것 같습니다!


3. hibernate validator 사용 설정
implement 추가하고,
validator 로 검사했을 때 invalid 시 발생하는 오류 핸들링해주는 코드 추가했습니다.


4. 전에 메일 인증코드 전송 api의 url이 변경되면서 api의 뉘앙스가 조금 바뀌어서
메서드 명도 기존 sendAuthEmail 에서 getAuthCodeEmail 로 변경했습니다.