### PR TITLE
[User] 로그아웃, 프로필 조회, 닉네임관련 작업

### DIFF
--- a/src/main/java/com/dungzi/backend/domain/univ/application/UnivAuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/univ/application/UnivAuthService.java
@@ -20,10 +20,9 @@ public class UnivAuthService {
     private final UnivAuthDao univAuthDao;
 
 
-    public UnivAuth getUnivAuthByUser(User user) {
+    public Optional<UnivAuth> getUnivAuthByUser(User user) {
         log.info("[SERVICE] getUnivAuthByUser");
-        return univAuthDao.findByUser(user)
-                .orElseThrow(() -> new AuthException(CommonCode.NOT_FOUND));
+        return univAuthDao.findByUser(user);
     }
 
     @Transactional

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -115,15 +115,16 @@ public class AuthController {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "확인 성공"),
-                    @ApiResponse(responseCode = "400", description = "request body 값 관련 오류")
+                    @ApiResponse(responseCode = "400", description = "request body 값 관련 오류"),
+                    @ApiResponse(responseCode = "409", description = "이미 존재하는 nickname 임")
             }
     )
     @PostMapping("/nickname")
-    public CommonResponse checkNicknameExist(@RequestBody @Valid UserRequestDto.NicknameOnly requestDto) {
+    public CommonResponse checkNicknameUnique(@RequestBody @Valid UserRequestDto.NicknameOnly requestDto) {
         log.info("[API] auth/nickname");
-        boolean isExist = authService.isNicknameExist(requestDto.getNickname());
+        authService.checkNicknameUnique(requestDto.getNickname());
         return CommonResponse.toResponse(CommonCode.OK,
-                UserAuthResponseDto.CheckNicknameExist.toDto(requestDto.getNickname(), isExist));
+                UserAuthResponseDto.CheckNicknameExist.toDto(requestDto.getNickname(), true));
     }
 
 

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -120,11 +121,11 @@ public class AuthController {
             }
     )
     @PostMapping("/nickname")
-    public CommonResponse checkNicknameUnique(@RequestBody @Valid UserRequestDto.NicknameOnly requestDto) {
+    public ResponseEntity<CommonResponse> checkNicknameUnique(@RequestBody @Valid UserRequestDto.NicknameOnly requestDto) {
         log.info("[API] auth/nickname");
         authService.checkNicknameUnique(requestDto.getNickname());
-        return CommonResponse.toResponse(CommonCode.OK,
-                UserAuthResponseDto.CheckNicknameExist.toDto(requestDto.getNickname(), true));
+        return ResponseEntity.ok(CommonResponse.toResponse(CommonCode.OK,
+                UserAuthResponseDto.CheckNicknameExist.toDto(requestDto.getNickname(), true)));
     }
 
 

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -103,6 +103,19 @@ public class AuthController {
         return CommonResponse.toResponse(CommonCode.CREATED, UserAuthResponseDto.SignUpByKakao.toDto(newUser));
     }
 
+    @Operation(summary = "로그아웃 api", description = "쿠키에 저장되어있던 액세스 토큰, 리프레시 토큰 값 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+            }
+    )
+    @GetMapping("/logout")
+    public CommonResponse logout(HttpServletResponse servletResponse) {
+        log.info("[API] auth/logout");
+        authService.removeCookieToken(servletResponse);
+        return CommonResponse.toResponse(CommonCode.OK, null);
+    }
+
 
     //카카오 로그인 콜백
     @Operation(summary = "카카오 로그인 콜백 api", description = "카카오 계정 연동 로그인에 사용되는 콜백 api")

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 @RequestMapping("/api/v1/auth") // cookie 에서 사용자 정보를 확인하지 않는 api 들
 public class AuthController {
     private final String LOGIN_SUCCESS_REDIRECT_URL = "http://localhost:3000";
-    private final String LOGIN_FAIL_REDIRECT_URL = "http://localhost:3000/login/kakao";
+    private final String LOGIN_FAIL_REDIRECT_URL = "http://localhost:3000/signup/policy";
     private final String LOGIN_FAIL_KAKAO_TOKEN_HEADER = "kakao-access-token";
 
     private final KakaoService kakaoService;

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -103,12 +103,21 @@ public class AuthController {
         return CommonResponse.toResponse(CommonCode.CREATED, UserAuthResponseDto.SignUpByKakao.toDto(newUser));
     }
 
-    @Operation(summary = "로그아웃 api", description = "쿠키에 저장되어있던 액세스 토큰, 리프레시 토큰 값 삭제")
+    @Operation(summary = "닉네임 중복 검사 api", description = "이미 존재하는 닉네임인지 확인하는 api")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+                    @ApiResponse(responseCode = "200", description = "확인 성공"),
+                    @ApiResponse(responseCode = "400", description = "request body 값 관련 오류")
             }
     )
+    @PostMapping("/nickname")
+    public CommonResponse checkNicknameExist(@RequestBody @Valid UserRequestDto.CheckNicknameExist requestDto) {
+        boolean isExist = authService.isNicknameExist(requestDto.getNickname());
+        return CommonResponse.toResponse(CommonCode.OK,
+                UserAuthResponseDto.CheckNicknameExist.toDto(requestDto.getNickname(), isExist));
+    }
+
+
     @GetMapping("/logout")
     public CommonResponse logout(HttpServletResponse servletResponse) {
         log.info("[API] auth/logout");

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -146,7 +146,7 @@ public class AuthController {
             }
     )
     @GetMapping("/kakao")
-    public void kakaoCallback(@RequestParam String state, @RequestParam String code, HttpServletResponse httpServletResponse) throws IOException {
+    public void kakaoCallback(@RequestParam @NotBlank String state, @RequestParam @NotBlank String code, HttpServletResponse httpServletResponse) throws IOException {
         log.info("[API] auth/kakao");
         log.info("state : {}", state);
 

--- a/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/AuthController.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/auth") // cookie 에서 사용자 정보를 확인하지 않는 api 들
 public class AuthController {
     private final String LOGIN_SUCCESS_REDIRECT_URL = "http://localhost:3000";
     private final String LOGIN_FAIL_REDIRECT_URL = "http://localhost:3000/login/kakao";

--- a/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -40,8 +41,8 @@ public class UserUtilController {
     public CommonResponse getUserProfile() {
         log.info("[API] users/profile");
         User user = authService.getUserFromSecurity();
-        UnivAuth univAuth = univAuthService.getUnivAuthByUser(user);
-        return CommonResponse.toResponse(CommonCode.OK, UserUtilResponseDto.GetUserProfile.toDto(user, univAuth));
+        Optional<UnivAuth> univAuthOp = univAuthService.getUnivAuthByUser(user);
+        return CommonResponse.toResponse(CommonCode.OK, UserUtilResponseDto.GetUserProfile.toDto(user, univAuthOp));
     }
 
     @Operation(summary = "대학교 이메일 인증 api", description = "대학교 이메일 인증 정보 저장")

--- a/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
@@ -7,17 +7,15 @@ import com.dungzi.backend.domain.univ.domain.UnivAuth;
 import com.dungzi.backend.domain.user.application.AuthService;
 import com.dungzi.backend.domain.user.domain.User;
 import com.dungzi.backend.domain.user.dto.UserRequestDto;
-import com.dungzi.backend.domain.user.dto.UserAuthResponseDto;
 import com.dungzi.backend.domain.user.dto.UserUtilResponseDto;
 import com.dungzi.backend.global.common.CommonCode;
 import com.dungzi.backend.global.common.CommonResponse;
-import com.dungzi.backend.global.common.error.AuthErrorCode;
-import com.dungzi.backend.global.common.error.AuthException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -64,5 +62,21 @@ public class UserUtilController {
 
         UnivAuth univAuth = univAuthService.updateUserEmailAuth(user, univ, requestDto.getUnivEmail(), requestDto.getIsEmailChecked());
         return CommonResponse.toResponse(CommonCode.OK, UserUtilResponseDto.UpdateEmailAuth.toDto(user, univAuth));
+    }
+
+    @Operation(summary = "닉네임 변경 api", description = "사용자 닉네임 변경")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "변경 성공"),
+                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가")
+            }
+    )
+    @Transactional
+    @PatchMapping("/nickname")
+    public CommonResponse updateNickname(@RequestBody @Valid UserRequestDto.NicknameOnly requestDto) {
+        log.info("[API] users/nickname");
+        authService.validateNickname(requestDto.getNickname());
+        authService.updateNickname(requestDto.getNickname());
+        return CommonResponse.toResponse(CommonCode.OK, null);
     }
 }

--- a/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
+++ b/src/main/java/com/dungzi/backend/domain/user/api/UserUtilController.java
@@ -25,7 +25,7 @@ import javax.validation.Valid;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/users") // cookie 에서 사용자 정보를 확인하는 api 들
 public class UserUtilController {
     private final AuthService authService;
     private final UnivService univService;

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -3,6 +3,8 @@ package com.dungzi.backend.domain.user.application;
 import com.dungzi.backend.domain.user.domain.User;
 import com.dungzi.backend.global.common.error.AuthException;
 import com.dungzi.backend.global.common.error.AuthErrorCode;
+import com.dungzi.backend.global.common.error.ValidErrorCode;
+import com.dungzi.backend.global.common.error.ValidException;
 import com.dungzi.backend.global.config.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -115,20 +117,21 @@ public class AuthService {
     }
 
 
-    public User signUpByKakao(User kakaoUser, Optional<String> nicknameOp) {
+    public User signUpByKakao(User kakaoUser, String nickname) {
         log.info("[SERVICE] signUpByKakao");
         Optional<User> userOptional = isExistUser(kakaoUser);
 
         if(userOptional.isPresent()){
             throw new AuthException(AuthErrorCode.ALREADY_EXIST_USER);
         }else{
-            kakaoUser.updateSignUpInfo(nicknameOp);
+            kakaoUser.updateSignUpInfo(nickname);
             kakaoUser.updateRoles(Collections.singletonList(ROLE_USER));
             return userDao.save(kakaoUser);
         }
     }
 
     public boolean isNicknameExist(String nickname) {
+        log.info("[SERVICE] isNicknameExist");
         return userDao.findByNickname(nickname).isPresent();
     }
 

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -84,6 +84,20 @@ public class AuthService {
         return cookieMap;
     }
 
+    public void removeCookieToken(HttpServletResponse servletResponse) {
+        log.info("[SERVICE] removeCookieToken");
+
+        List<Cookie> cookieList = new ArrayList<>();
+        cookieList.add(new Cookie(jwtTokenProvider.ACCESS_TOKEN_HEADER_NAME, null));
+        cookieList.add(new Cookie(jwtTokenProvider.REFRESH_TOKEN_HEADER_NAME, null));
+
+        for(Cookie cookie : cookieList) {
+            cookie.setMaxAge(0);
+            cookie.setPath("/");
+            servletResponse.addCookie(cookie);
+        }
+    }
+
 
     public User login(User user) throws AuthException {
         log.info("[SERVICE] login");

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -132,9 +132,12 @@ public class AuthService {
         }
     }
 
-    public boolean isNicknameExist(String nickname) {
+    public void checkNicknameUnique(String nickname) {
         log.info("[SERVICE] isNicknameExist");
-        return userDao.findByNickname(nickname).isPresent();
+        userDao.findByNickname(nickname)
+                .ifPresent(n -> {
+                    throw new ValidException(ValidErrorCode.NICKNAME_ALREADY_EXIST);
+                });
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -1,8 +1,6 @@
 package com.dungzi.backend.domain.user.application;
 
 import com.dungzi.backend.domain.user.domain.User;
-import com.dungzi.backend.domain.user.dto.UserRequestDto;
-import com.dungzi.backend.global.common.CommonCode;
 import com.dungzi.backend.global.common.error.AuthException;
 import com.dungzi.backend.global.common.error.AuthErrorCode;
 import com.dungzi.backend.global.config.security.jwt.JwtTokenProvider;
@@ -128,6 +126,10 @@ public class AuthService {
             kakaoUser.updateRoles(Collections.singletonList(ROLE_USER));
             return userDao.save(kakaoUser);
         }
+    }
+
+    public boolean isNicknameExist(String nickname) {
+        return userDao.findByNickname(nickname).isPresent();
     }
 
     //TODO  추후 제거

--- a/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
+++ b/src/main/java/com/dungzi/backend/domain/user/application/AuthService.java
@@ -69,7 +69,7 @@ public class AuthService {
         cookieMap.forEach( (key, cookie) -> {
             cookie.setHttpOnly(true);
             cookie.setPath("/");
-            //cookie.setSecure(true); //https 상에서만 동작
+            cookie.setSecure(true); //https 상에서만 동작
         });
 
         return cookieMap;

--- a/src/main/java/com/dungzi/backend/domain/user/domain/User.java
+++ b/src/main/java/com/dungzi/backend/domain/user/domain/User.java
@@ -2,6 +2,7 @@ package com.dungzi.backend.domain.user.domain;
 
 import com.dungzi.backend.global.common.BaseTimeEntity;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.springframework.security.core.GrantedAuthority;
@@ -27,7 +28,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Type(type = "uuid-char")
     private UUID userId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickname; //kakao 필수 동의 항목
 
     @Column(nullable = false)
@@ -55,10 +56,10 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.roles = roles;
     }
 
-    public void updateSignUpInfo(Optional<String> nicknameOp) {
+    public void updateSignUpInfo(String nickname) {
         //이메일 변경
-//        Optional<String> nicknameOp = Optional.ofNullable(requestDto.getNickname());
-        nicknameOp.ifPresent(nickname -> this.nickname = nickname);
+//        nicknameOp.ifPresent(nickname -> this.nickname = nickname);
+        this.nickname = nickname;
     }
 
     //////////-- set user roles(Authentication) : implements UserDetails --//////////

--- a/src/main/java/com/dungzi/backend/domain/user/domain/User.java
+++ b/src/main/java/com/dungzi/backend/domain/user/domain/User.java
@@ -2,7 +2,6 @@ package com.dungzi.backend.domain.user.domain;
 
 import com.dungzi.backend.global.common.BaseTimeEntity;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.springframework.security.core.GrantedAuthority;
@@ -56,8 +55,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.roles = roles;
     }
 
-    public void updateSignUpInfo(String nickname) {
-        //이메일 변경
+    public void updateNickname(String nickname) {
 //        nicknameOp.ifPresent(nickname -> this.nickname = nickname);
         this.nickname = nickname;
     }

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserAuthResponseDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserAuthResponseDto.java
@@ -1,6 +1,5 @@
 package com.dungzi.backend.domain.user.dto;
 
-import com.dungzi.backend.domain.univ.domain.UnivAuth;
 import com.dungzi.backend.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +13,6 @@ public class UserAuthResponseDto {
     @Builder
     @Data
     public static class SendEmailAuth {
-//        private String uuid;
         private String email;
         private String authCode;
     }
@@ -37,6 +35,20 @@ public class UserAuthResponseDto {
         public static SignUpByKakao toDto(User user){
             return SignUpByKakao.builder()
                     .uuid(user.getUserId())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Data
+    public static class CheckNicknameExist {
+        private String nickname;
+        private Boolean isExsit;
+
+        public static CheckNicknameExist toDto(String nickname, Boolean isExsit){
+            return CheckNicknameExist.builder()
+                    .nickname(nickname)
+                    .isExsit(isExsit)
                     .build();
         }
     }

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserAuthResponseDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserAuthResponseDto.java
@@ -43,12 +43,12 @@ public class UserAuthResponseDto {
     @Data
     public static class CheckNicknameExist {
         private String nickname;
-        private Boolean isExsit;
+        private Boolean isUnique;
 
-        public static CheckNicknameExist toDto(String nickname, Boolean isExsit){
+        public static CheckNicknameExist toDto(String nickname, Boolean isUnique){
             return CheckNicknameExist.builder()
                     .nickname(nickname)
-                    .isExsit(isExsit)
+                    .isUnique(isUnique)
                     .build();
         }
     }

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
@@ -37,4 +37,10 @@ public class UserRequestDto {
 
         private String nickname;
     }
+
+    @Data
+    public static class CheckNicknameExist {
+        @NotBlank
+        private String nickname;
+    }
 }

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
@@ -8,7 +8,7 @@ public class UserRequestDto {
 
     @Data
     public static class UpdateEmailAuth {
-        @Pattern(regexp = "^[U][0-9]{4}$")
+        @Pattern(regexp = "^U[0-9]{4}$")
         @NotBlank
         private String univId;
 
@@ -29,12 +29,13 @@ public class UserRequestDto {
         @NotNull
         private Boolean isUnivAuth;
 
-        @Pattern(regexp = "^[U][0-9]{4}$")
+        @Pattern(regexp = "^U[0-9]{4}$")
         private String univId;
 
         @Email
         private String univEmail;
 
+        @NotBlank
         private String nickname;
     }
 

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserRequestDto.java
@@ -40,7 +40,7 @@ public class UserRequestDto {
     }
 
     @Data
-    public static class CheckNicknameExist {
+    public static class NicknameOnly {
         @NotBlank
         private String nickname;
     }

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserUtilResponseDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserUtilResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public class UserUtilResponseDto {
@@ -21,14 +22,15 @@ public class UserUtilResponseDto {
         private String email;
         private String univName;
 
-        public static GetUserProfile toDto(User user, UnivAuth univAuth){
-            return GetUserProfile.builder()
+        public static GetUserProfile toDto(User user, Optional<UnivAuth> univAuthOp){
+            GetUserProfile dto = GetUserProfile.builder()
                     .userId(user.getUserId())
                     .email(user.getEmail())
                     .nickname(user.getNickname())
                     .profileImg(user.getProfileImg())
-                    .univName(univAuth.getUniv().getUnivName())
                     .build();
+            univAuthOp.ifPresent(univAuth -> dto.setUnivName(univAuth.getUniv().getUnivName()));
+            return dto;
         }
     }
 

--- a/src/main/java/com/dungzi/backend/domain/user/dto/UserUtilResponseDto.java
+++ b/src/main/java/com/dungzi/backend/domain/user/dto/UserUtilResponseDto.java
@@ -24,6 +24,7 @@ public class UserUtilResponseDto {
         public static GetUserProfile toDto(User user, UnivAuth univAuth){
             return GetUserProfile.builder()
                     .userId(user.getUserId())
+                    .email(user.getEmail())
                     .nickname(user.getNickname())
                     .profileImg(user.getProfileImg())
                     .univName(univAuth.getUniv().getUnivName())

--- a/src/main/java/com/dungzi/backend/global/common/error/ValidErrorCode.java
+++ b/src/main/java/com/dungzi/backend/global/common/error/ValidErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ValidErrorCode implements Code {
     REQUIRED_VALUE(HttpStatus.BAD_REQUEST, "필수 값이 누락되었습니다."), //400
+    NICKNAME_FORBIDDEN(HttpStatus.CONFLICT, "사용할 수 없는 형식의 닉네임입니다."), //409
+    NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "중복된 닉네임 입니다.") //409
     ;
 
     @Override

--- a/src/main/java/com/dungzi/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dungzi/backend/global/config/SwaggerConfig.java
@@ -14,10 +14,17 @@ public class SwaggerConfig {
     private static final String BASIC_API_PATH="/api/v1";
 
     @Bean
-    public GroupedOpenApi login() {
+    public GroupedOpenApi user() {
         return GroupedOpenApi.builder()
-                .group("login")
+                .group("user")
                 .pathsToMatch(BASIC_API_PATH+"/users/**")
+                .build();
+    }
+    @Bean
+    public GroupedOpenApi auth() {
+        return GroupedOpenApi.builder()
+                .group("auth")
+                .pathsToMatch(BASIC_API_PATH+"/auth/**")
                 .build();
     }
     @Bean

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,2 +1,3 @@
 -- 아래 sql 문이 ddl-auto: create 모드 시 실행됩니다
-insert into univ(univ_Id, univ_name, email_domain) values ('U0001', '한양대학교 에리카', 'hanyang.ac.kr');
+-- 네이버대학교는 개발편의를 위한 임시값입니다.
+insert into univ(univ_Id, univ_name, email_domain) values ('U0001', '한양대학교 에리카', 'hanyang.ac.kr'), ('U9999', '네이버대학교', 'naver.com');


### PR DESCRIPTION
아래 내용들 작업했습니다.

1. 유저 프로필 조회 api 완성
2. 로그아웃 api, 닉네임 중복체크 api, 닉네임 변경 api 생성
3. 회원가입 시 닉네임 필수값으로 변경, 닉네임 유효성검사(중복, 생성규칙 검사) 추가
4. 로그인 실패 시 프론트 측 리다이렉트 url 변경
5. DB초기화와 닉네임 컬럼 unique 조건 추가

+)추가 작업

6. 로그인 api 처리후 프론트로 리다이렉트되는 위치 두 가지로 구분
- 배포된 프론트 페이지 https://dankan.co.kr/~
- 로컬 프론트 페이지 http://localhost:3000/~
7. swagger config 수정
8. 닉네임 중복체크 api 응답 수정, ResponseEntity 적용

확인 감사합니다!